### PR TITLE
Update nerfacc from 0.3.3 to 0.5.3

### DIFF
--- a/datasets/colmap.py
+++ b/datasets/colmap.py
@@ -138,11 +138,10 @@ def create_spheric_poses(cameras, n_steps=120):
     return all_c2w
 
 from models.utils import scale_anything
-from nerfacc import ContractionType
 def contract_to_unisphere(x, radius, contraction_type):
-    if contraction_type == ContractionType.AABB:
+    if contraction_type =='AABB':
         x = scale_anything(x, (-radius, radius), (0, 1))
-    elif contraction_type == ContractionType.UN_BOUNDED_SPHERE:
+    elif contraction_type == 'UN_BOUNDED_SPHERE':
         x = scale_anything(x, (-radius, radius), (0, 1))
         x = x * 2 - 1  # aabb is at [-1, 1]
         mag = x.norm(dim=-1, keepdim=True)
@@ -319,7 +318,7 @@ class ColmapDatasetBase():
         self.all_points_confidence = self.all_points_confidence.float()
         self.all_points = self.all_points.float()
         self.pts3d_normal = self.pts3d_normal.float()
-        self.all_points_ = contract_to_unisphere(self.all_points, 1.0, ContractionType.AABB) # points normalized to (0, 1)
+        self.all_points_ = contract_to_unisphere(self.all_points, 1.0, 'AABB') # points normalized to (0, 1)
 
     def query_radius_occ(self, query_points, radius=0.01):
         

--- a/models/geometry.py
+++ b/models/geometry.py
@@ -12,22 +12,19 @@ from models.utils import scale_anything, get_activation, cleanup, chunk_batch
 from models.network_utils import get_encoding, get_mlp, get_encoding_with_network
 from utils.misc import get_rank
 from systems.utils import update_module_step
-from nerfacc import ContractionType
 
 import trimesh
 
 def contract_to_unisphere(x, radius, contraction_type):
-    if contraction_type == ContractionType.AABB:
+    if contraction_type == 'AABB':
         x = scale_anything(x, (-radius, radius), (0, 1))
-    elif contraction_type == ContractionType.UN_BOUNDED_SPHERE:
+    else:
         x = scale_anything(x, (-radius, radius), (0, 1))
         x = x * 2 - 1  # aabb is at [-1, 1]
         mag = x.norm(dim=-1, keepdim=True)
         mask = mag.squeeze(-1) > 1
         x[mask] = (2 - 1 / mag[mask]) * (x[mask] / mag[mask])
         x = x / 4 + 0.5  # [-inf, inf] is at [0, 1]
-    else:
-        raise NotImplementedError
     return x
 
 '''


### PR DESCRIPTION
- Replaced ContractionType enum handling with string comparisons for contraction type checks in colmap.py, geometry.py, nerf.py, and neus.py.
- Renamed OccupancyGrid to OccGridEstimator in nerf.py and neus.py.
- Removed unnecessary import references in nerf.py and neus.py.
- Replaced the ray marching method with occupancy grid's sampling method in nerf.py and neus.py.
- Updated parameters and calls to accumulate_along_rays function in nerf.py and neus.py.
- Corrected various naming and formatting inconsistencies across files.